### PR TITLE
workaround for M1 audio description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# odd cache files
+.dccache

--- a/README.md
+++ b/README.md
@@ -15,8 +15,32 @@ Then, run the following command to start the server:
 
 To find out more about the API key and configure your agent, visit the [Carter API](https://www.carterapi.com/).
 
+<h3>PyAudio for M1 Macs</h3>
+
+to install PyAudo for M1 Macs, this will require a small workaround, as PortAudio is not automatically detected.
+
+first, we need to install PortAudio
+
+```brew install portaudio```
+
+then, we need to create a new file:
+
+```nano ~/.pydistutils.cfg```
+
+the contents of that file may vary slightly (ie, version number)
+
+```
+[build_ext]
+include_dirs=/opt/homebrew/Cellar/portaudio/19.7.0/include/
+library_dirs=/opt/homebrew/Cellar/portaudio/19.7.0/lib/
+```
+
+where 19.7.0 should be replaced with the portaudio version you get installed.
+
+this should be executed BEFORE running the `pip install -r requirements.txt` command
+
 <h2>Known Issues:</h2>
-- M1 Mac doesn't seem to support PyAudio.
+- M1 Mac doesn't seem to support PyAudio (workaround awaiting testing from others)
 
 - Speech-to-text Performance is not optimized and could be optimized in conjunction with n-grams. 
 


### PR DESCRIPTION
This adds instructions for how to Work around the M1 Mac Audio issue, also adds .dccache to the gitignore (common file created by vscode on M1 macs)