### PR TITLE
Added an extra step

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ first, we need to install PortAudio
 brew install portaudio
 ```
 
+<h3> If the command 'brew' is not found, run this command and then try again.</h3>
+
+```
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+```
+
 then, we need to create a new file:
 
 ```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then, run the following command to start the server:
 To find out more about the API key and configure your agent, visit the [Carter](https://www.carterlabs.ai/) website.
 
 <h3>PyAudio for M1 Macs</h3>
-to install PyAudo for M1 Macs, this will require a small workaround, as PortAudio is not automatically detected.
+to install PyAudio for M1 Macs, this will require a small workaround, as PortAudio is not automatically detected.
 first, we need to install PortAudio
 
 ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ first, we need to install PortAudio
 brew install portaudio
 ```
 
-<h3> If the command 'brew' is not found, run this command and then try again.</h3>
+If the command 'brew' is not found, run this command and then try the previous step again.
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ first, we need to install PortAudio
 brew install portaudio
 ```
 
-If the command 'brew' is not found, run this command and then try the previous step again.
+if the command 'brew' is not found, run this command and then try the previous step again:
 
 ```
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"


### PR DESCRIPTION
Common issue M1 users have with installing PortAudio for PyAudio is that they don't already have HomeBrew installed, and have to go scrounging through the internet to look for it, so I threw in a sort-of safety net in the ReadMe 